### PR TITLE
Added missing header comment metadata

### DIFF
--- a/mainwp-child-reports.php
+++ b/mainwp-child-reports.php
@@ -8,6 +8,10 @@
  * Author: MainWP
  * Author URI: https://mainwp.com
  * Version: 2.0.4
+ * Requires at least: 3.6
+ * Text Domain: mainwp-child-reports
+ * License: GPLv2 or later
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
 
  /**

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Author: mainwp
 Author URI: https://mainwp.com
 Plugin URI: https://mainwp.com
 Requires at least: 3.6
-Tested up to: 5.4.1
+Tested up to: 5.4
 Requires PHP: 5.6
 Stable tag: 2.0.4
 License: GPLv2 or later


### PR DESCRIPTION
*mainwp-child-reports.php*
- Added the same "Requires at least" of MainWP Dashboard.
- Because "Requires at least" is below 4.6. we need to set a Text Domain in mainwp-child-reports.php and it needs to be mainwp-child-reports to correctly internationalize the plugin. (More info: https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains)
- Setting a License header is mandatory for new plugins since April 2020. I added the same that MainWP Dashboard: “GPLv2 or later” (More info: https://developer.wordpress.org/plugins/wordpress-org/detailed-plugin-guidelines/#1-plugins-must-be-compatible-with-the-gnu-general-public-license)

*readme.txt*
- Added "Tested up to: 5.4". We can limit the "Tested up to:" to just the major release (e.g. 5.4). The repository will automatically add the latest minor version as plugins shouldn’t break with a minor update. So, you don't need to update it manually every time a minor release is launched.