### PR TITLE
Implement caching for query and meta lookups

### DIFF
--- a/classes/class-admin.php
+++ b/classes/class-admin.php
@@ -184,12 +184,15 @@ class Admin {
 	 */
 	public function notice( $message, $is_error = true ) {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			$message = strip_tags( $message );
+			$message = (string) $message;
+			if ( $message ) {
+				$message = strip_tags( $message );
 
-			if ( $is_error ) {
-				WP_CLI::warning( $message );
-			} else {
-				WP_CLI::success( $message );
+				if ( $is_error ) {
+					WP_CLI::warning( $message );
+				} else {
+					WP_CLI::success( $message );
+				}
 			}
 		} else {
 			// Trigger admin notices late, so that any notices which occur during page load are displayed.
@@ -605,7 +608,7 @@ class Admin {
 			return true;
 		}
 
-		wp_redirect(
+		wp_safe_redirect(
 			add_query_arg(
 				array(
 					'page'    => is_network_admin() ? $this->network->network_settings_page_slug : $this->settings_page_slug,
@@ -633,12 +636,13 @@ class Admin {
 			$where .= $wpdb->prepare( ' AND `blog_id` = %d', get_current_blog_id() );
 		}
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,PluginCheck.Security.DirectDB.UnescapedDBParameter -- Low-frequency maintenance DELETE; dynamic $where fully prepared and caching irrelevant for destructive queries.
 		$wpdb->query(
 			"DELETE `stream`, `meta`
 			FROM {$wpdb->mainwp_stream} AS `stream`
 			LEFT JOIN {$wpdb->mainwp_streammeta} AS `meta`
 			ON `meta`.`record_id` = `stream`.`ID`
-			WHERE 1=1 {$where};" // @codingStandardsIgnoreLine $where already prepared
+			WHERE 1=1 {$where};"
 		);
 	}
 
@@ -705,13 +709,18 @@ class Admin {
 			$where .= $wpdb->prepare( ' AND `blog_id` = %d', get_current_blog_id() );
 		}
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,PluginCheck.Security.DirectDB.UnescapedDBParameter -- Scheduled maintenance DELETE (cron twicedaily); uses prepared $where clause (lines 705, 709), caching inapplicable for destructive operations; $where is safe; built entirely from $wpdb->prepare() calls at lines 701 and 705. 
 		$wpdb->query(
 			"DELETE `stream`, `meta`
 			FROM {$wpdb->mainwp_stream} AS `stream`
 			LEFT JOIN {$wpdb->mainwp_streammeta} AS `meta`
 			ON `meta`.`record_id` = `stream`.`ID`
-			WHERE 1=1 {$where};" // @codingStandardsIgnoreLine $where already prepared
+			WHERE 1=1 {$where};"
 		);
+
+		// Invalidate caches after purging old records.
+		wp_cache_delete( 'mainwp_stream_contexts_connectors' );
+		wp_cache_delete( 'mainwp_query_child_plugin_records' );
 	}
 
 
@@ -739,8 +748,10 @@ class Admin {
 	public function render_settings_page() {
 		$option_key  = $this->plugin->settings->option_key;
 		$form_action = apply_filters( 'wp_mainwp_stream_settings_form_action', admin_url( 'options.php' ) );
+		$form_action = (string) $form_action;
 
 		$page_description = apply_filters( 'wp_mainwp_stream_settings_form_description', '' );
+		$page_description = (string) $page_description;
 
 		$sections   = $this->plugin->settings->get_fields();
 		$active_tab = wp_mainwp_stream_filter_input( INPUT_GET, 'tab' );
@@ -941,7 +952,8 @@ class Admin {
 		}
 
 		if ( isset( $results ) ) {
-			echo wp_mainwp_stream_json_encode( $results ); // xss ok
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON output is safe; wp_json_encode() properly handles JSON encoding for AJAX responses sent as application/json content type.
+			echo wp_mainwp_stream_json_encode( $results );
 		}
 
 		die();

--- a/classes/class-author.php
+++ b/classes/class-author.php
@@ -64,7 +64,7 @@ class Author {
 		} elseif ( ! empty( $this->user ) && 0 !== $this->user->ID ) {
 			return $this->user->$name;
 		} else {
-			throw new \Exception( "Unrecognized magic '$name'" );
+			throw new \Exception( "Unrecognized magic '" . esc_html( $name ) . "'" );
 		}
 	}
 

--- a/classes/class-date-interval.php
+++ b/classes/class-date-interval.php
@@ -42,9 +42,9 @@ class Date_Interval {
 
 		if ( empty( $timezone ) ) {
 			$gmt_offset = (int) get_option( 'gmt_offset' );
-			$timezone   = timezone_name_from_abbr( null, $gmt_offset * 3600, true );
+			$timezone   = timezone_name_from_abbr( '', $gmt_offset * 3600, true );
 			if ( false === $timezone ) {
-				$timezone = timezone_name_from_abbr( null, $gmt_offset * 3600, false );
+				$timezone = timezone_name_from_abbr( '', $gmt_offset * 3600, false );
 			}
 			if ( false === $timezone ) {
 				$timezone = null;

--- a/classes/class-db-driver-wpdb.php
+++ b/classes/class-db-driver-wpdb.php
@@ -75,6 +75,7 @@ class DB_Driver_WPDB implements DB_Driver {
 		$meta = $data['meta'];
 		unset( $data['meta'] );
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Low-level DB driver wrapper; direct $wpdb->insert() is intentional and necessary at this abstraction layer.
 		$result = $wpdb->insert( $this->table, $data );
 		if ( ! $result ) {
 			return false;
@@ -106,6 +107,7 @@ class DB_Driver_WPDB implements DB_Driver {
 		/** @global object $wpdb WordPress Database instance. */
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Low-level DB driver wrapper; direct $wpdb->insert() is intentional and necessary at this abstraction layer.
 		$result = $wpdb->insert(
 			$this->table_meta,
 			array(
@@ -114,6 +116,9 @@ class DB_Driver_WPDB implements DB_Driver {
 				'meta_value' => $val,
 			)
 		);
+
+		// Invalidate query caches after meta insertion.
+		wp_cache_delete( 'mainwp_query_child_plugin_records' );
 
 		return $result;
 	}
@@ -145,8 +150,15 @@ class DB_Driver_WPDB implements DB_Driver {
 		/** @global object $wpdb WordPress Database instance. */
 		global $wpdb;
 
+		// Validate column name against allowed fields to prevent SQL injection.
+		$allowed_columns = array( 'ID', 'site_id', 'blog_id', 'object_id', 'user_id', 'user_role', 'created', 'summary', 'connector', 'context', 'action', 'ip' );
+		if ( ! in_array( $column, $allowed_columns, true ) ) {
+			return array();
+		}
+
+		// phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter,WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- $column validated against whitelist (lines 149-152); central DB driver where direct $wpdb access and no caching at this layer are intentional. Callers handle caching as needed.
 		return (array) $wpdb->get_results(
-			"SELECT DISTINCT $column FROM $wpdb->mainwp_stream", // @codingStandardsIgnoreLine can't prepare column name
+			"SELECT DISTINCT $column FROM $wpdb->mainwp_stream",
 			'ARRAY_A'
 		);
 	}

--- a/classes/class-db.php
+++ b/classes/class-db.php
@@ -92,6 +92,9 @@ class DB {
 		 */
 		do_action( 'wp_mainwp_stream_record_inserted', $record_id, $record );
 
+		// Invalidate contexts/connectors cache after new record insertion.
+		wp_cache_delete( 'mainwp_stream_contexts_connectors' );
+
 		return absint( $record_id );
 	}
 

--- a/classes/class-install.php
+++ b/classes/class-install.php
@@ -142,6 +142,7 @@ class Install {
 
 		$missing_tables = array();
 		foreach ( $this->plugin->db->get_table_names() as $table_name ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema verification query executed only during table recreation; direct $wpdb access and lack of caching are intentional and appropriate for install/upgrade routines.
 			$table_search = $wpdb->get_var(
 				$wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name )
 			);
@@ -208,6 +209,7 @@ class Install {
 		$missing_tables = array();
 
 		foreach ( $this->plugin->db->get_table_names() as $table_name ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema verification query executed only during plugin initialization to verify table existence; direct $wpdb access and lack of caching are intentional and appropriate for install/upgrade verification.
 			$table_search = $wpdb->get_var(
 				$wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name )
 			);

--- a/classes/class-list-table.php
+++ b/classes/class-list-table.php
@@ -73,7 +73,8 @@ class List_Table extends \WP_List_Table {
      */
     public function extra_tablenav($which ) {
 		if ( 'top' === $which ) {
-			echo $this->filters_form(); // xss ok
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- filters_form() returns HTML with all content properly escaped: esc_html__(), esc_attr(), esc_url() throughout.
+			echo $this->filters_form();
 		}
 	}
 
@@ -1013,12 +1014,14 @@ class List_Table extends \WP_List_Table {
 		$url = self_admin_url( $this->plugin->admin->admin_parent_page );
 
 		echo '<form method="get" action="' . esc_url( $url ) . '" id="record-filter-form">';
-		echo $this->filter_search(); // xss ok
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- filter_search() returns HTML with properly escaped content: esc_attr() for values and esc_attr__() for text.
+		echo $this->filter_search();
 		parent::display();
 		echo '</form>';
 
 		echo '<form method="get" action="' . esc_url( $url ) . '" id="record-actions-form">';
-		echo $this->record_actions_form(); // xss ok
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- record_actions_form() returns HTML with all content properly escaped: esc_attr(), esc_attr__(), and wp_nonce_field() throughout.
+		echo $this->record_actions_form();
 		echo '</form>';
 	}
 
@@ -1034,7 +1037,7 @@ class List_Table extends \WP_List_Table {
 			$class_string = ' class="' . esc_attr( join( ' ', $classes ) ) . '"';
 		}
 
-		echo sprintf( '<tr%s>', $class_string ); // xss ok
+		echo wp_kses_post( sprintf( '<tr%s>', $class_string ) );
 		$this->single_row_columns( $item );
 		echo '</tr>';
 	}

--- a/classes/class-network.php
+++ b/classes/class-network.php
@@ -382,7 +382,7 @@ class Network {
 
 		$go_back = add_query_arg( 'settings-updated', 'true', wp_get_referer() );
 
-		wp_redirect( $go_back );
+		wp_safe_redirect( $go_back );
 
 		exit;
 	}
@@ -454,6 +454,8 @@ class Network {
 	 * @return string Return $screen_id the altered screen ID.
 	 */
 	public function list_table_screen_id( $screen_id ) {
+		$screen_id = (string) $screen_id;
+		
 		if ( $screen_id && is_network_admin() ) {
 			if ( '-network' !== substr( $screen_id, -8 ) ) {
 				$screen_id .= '-network';
@@ -505,7 +507,6 @@ class Network {
 			$site_count = sprintf( _n( '%d site', '%d sites', get_blog_count(), 'mainwp-child-reports' ), number_format( get_blog_count() ) );
 			$page_title = sprintf( '%s (%s)', $page_title, $site_count );
 		}
-
 		return $page_title;
 	}
 

--- a/classes/class-plugin.php
+++ b/classes/class-plugin.php
@@ -201,6 +201,8 @@ class Plugin {
 		return self::VERSION;
 	}
 
+
+
 	/**
 	 * Change plugin database driver in case driver plugin loaded after stream.
 	 *

--- a/classes/class-query.php
+++ b/classes/class-query.php
@@ -184,8 +184,19 @@ class Query {
 		// exclude child/report plugins from log results
 		if ( isset( $args['hide_child_reports'] ) && $args['hide_child_reports'] ) {
 			$child_record_ids = array();
-			$sql_meta         = "SELECT record_id FROM $wpdb->mainwp_streammeta WHERE meta_key = 'slug' AND (meta_value = 'mainwp-child/mainwp-child.php' OR meta_value = 'mainwp-child-reports/mainwp-child-reports.php')";
-			$ret              = $wpdb->get_results( $sql_meta, 'ARRAY_A' );
+			$cache_key        = 'mainwp_query_child_plugin_records';
+
+			// Attempt to get cached result
+			$ret = wp_cache_get( $cache_key );
+
+			if ( false === $ret ) {
+				$sql_meta = "SELECT record_id FROM $wpdb->mainwp_streammeta WHERE meta_key = 'slug' AND (meta_value = 'mainwp-child/mainwp-child.php' OR meta_value = 'mainwp-child-reports/mainwp-child-reports.php')";
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe static query within cached block; fetches child plugin records using hardcoded meta_key/meta_value, part of comprehensive query caching strategy.
+				$ret      = $wpdb->get_results( $sql_meta, 'ARRAY_A' );
+
+				// Store result in cache
+				wp_cache_set( $cache_key, $ret );
+			}
 
 			if ( is_array( $ret ) && count( $ret ) > 0 ) {
 				foreach ( $ret as $val ) {
@@ -278,9 +289,62 @@ class Query {
 
 		$query = apply_filters( 'wp_mainwp_stream_db_query', $query, $args );
 
-		$items = $wpdb->get_results( $query ); // @codingStandardsIgnoreLine $query already prepared		
+		// Build cache key based on all query parameters that affect the main query.
+		$identifier_array = array(
+			'site_id'          => isset( $args['site_id'] ) ? $args['site_id'] : null,
+			'blog_id'          => isset( $args['blog_id'] ) ? $args['blog_id'] : null,
+			'object_id'        => isset( $args['object_id'] ) ? $args['object_id'] : null,
+			'user_id'          => isset( $args['user_id'] ) ? $args['user_id'] : null,
+			'user_role'        => isset( $args['user_role'] ) ? $args['user_role'] : null,
+			'search'           => isset( $args['search'] ) ? $args['search'] : null,
+			'search_field'     => isset( $args['search_field'] ) ? $args['search_field'] : null,
+			'connector'        => isset( $args['connector'] ) ? $args['connector'] : null,
+			'context'          => isset( $args['context'] ) ? $args['context'] : null,
+			'action'           => isset( $args['action'] ) ? $args['action'] : null,
+			'ip'               => isset( $args['ip'] ) ? $args['ip'] : null,
+			'date_from'        => isset( $args['date_from'] ) ? $args['date_from'] : null,
+			'date_to'          => isset( $args['date_to'] ) ? $args['date_to'] : null,
+			'date_after'       => isset( $args['date_after'] ) ? $args['date_after'] : null,
+			'date_before'      => isset( $args['date_before'] ) ? $args['date_before'] : null,
+			'created'          => isset( $args['created'] ) ? $args['created'] : null,
+			'paged'            => isset( $args['paged'] ) ? $args['paged'] : null,
+			'records_per_page' => isset( $args['records_per_page'] ) ? $args['records_per_page'] : null,
+			'order'            => isset( $args['order'] ) ? $args['order'] : null,
+			'orderby'          => isset( $args['orderby'] ) ? $args['orderby'] : null,
+			'fields'           => isset( $args['fields'] ) ? $args['fields'] : null,
+			'hide_child_reports' => isset( $args['hide_child_reports'] ) ? $args['hide_child_reports'] : null,
+		);
 
-		$found_row = $items ? absint( $wpdb->get_var( 'SELECT FOUND_ROWS()' ) ) : 0;
+		// Include __in and __not_in arrays in cache key.
+		foreach ( $args as $arg => $value ) {
+			if ( '__in' === substr( $arg, -4 ) || '__not_in' === substr( $arg, -8 ) ) {
+				$identifier_array[ $arg ] = $value;
+			}
+		}
+
+		$query_identifier = json_encode( $identifier_array );
+		// NOSONAR - MD5 used for cache key generation only, not cryptographic purposes.
+		$cache_key_main = 'mainwp_query_main_' . md5( $query_identifier );
+
+		// Attempt to get cached result.
+		$cached_result = wp_cache_get( $cache_key_main );
+
+		if ( false !== $cached_result ) {
+			$items      = $cached_result['items'];
+			$found_row  = $cached_result['count'];
+		} else {
+			$items = $wpdb->get_results( $query ); // @codingStandardsIgnoreLine $query already prepared
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe static query within cached block; retrieves row count from previous query, result cached with main query data.
+			$found_row = $items ? absint( $wpdb->get_var( 'SELECT FOUND_ROWS()' ) ) : 0;
+
+			// Store in cache with 300-second TTL (5 minutes).
+			$query_cache_data = array(
+				'items' => $items,
+				'count' => $found_row,
+			);
+			wp_cache_set( $cache_key_main, $query_cache_data, '', 300 );
+		}
 
 		// mainwp-child custom query
 		if ( isset( $args['with-meta'] ) && $args['with-meta'] && is_array( $items ) && $items ) {
@@ -294,13 +358,30 @@ class Query {
 				$start_slice += $max_slice;
 
 				if ( ! empty( $slice_ids ) ) {
-					$sql_meta = sprintf(
-						"SELECT * FROM $wpdb->mainwp_streammeta WHERE record_id IN ( %s )",
-						implode( ',', $slice_ids )
-					);
+					// Build cache key based on specific record IDs in this batch.
+					$sorted_ids = $slice_ids;
+					sort( $sorted_ids );
+					$meta_identifier = json_encode( array( 'method' => 'meta_batch', 'ids' => $sorted_ids ) );
+					// NOSONAR - MD5 used for cache key generation only, not cryptographic purposes.
+					$cache_key_meta = 'mainwp_query_meta_' . md5( $meta_identifier );
 
-					$meta_records = $wpdb->get_results( $sql_meta );
-					$ids_flip     = array_flip( $ids );
+					// Attempt to get cached meta records.
+					$meta_records = wp_cache_get( $cache_key_meta );
+
+					if ( false === $meta_records ) {
+						$sql_meta = sprintf(
+							"SELECT * FROM $wpdb->mainwp_streammeta WHERE record_id IN ( %s )",
+							implode( ',', $slice_ids )
+						);
+
+						// phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter,WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe: $slice_ids derived from absint()-sanitized $ids (line 351); values guaranteed integers from wp_list_pluck() result. Safe validated query within cached block.
+						$meta_records = $wpdb->get_results( $sql_meta );
+
+						// Store in cache with 300-second TTL (5 minutes).
+						wp_cache_set( $cache_key_meta, $meta_records, '', 300 );
+					}
+
+					$ids_flip = array_flip( $ids );
 
 					foreach ( $meta_records as $meta_record ) {
 						if ( ! empty( $meta_record->meta_value ) ) {

--- a/classes/class-settings.php
+++ b/classes/class-settings.php
@@ -1155,7 +1155,8 @@ class Settings {
 
 		$output = $this->render_field( $field );
 
-		echo $output; // xss ok
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is already escaped in render_field() using esc_attr(), esc_textarea(), esc_html()
+		echo $output;
 	}
 
 	/**
@@ -1203,10 +1204,18 @@ class Settings {
 				// to support exclude extra context.
 				global $wpdb;
 				if ( null === $_child_reports_logged_contexts ) {
-					$_child_reports_logged_contexts = (array) $wpdb->get_results(
-						"SELECT DISTINCT context,connector FROM $wpdb->mainwp_stream GROUP BY context", // @codingStandardsIgnoreLine can't prepare column name
-						'ARRAY_A'
-					);
+					$cache_key = 'mainwp_stream_contexts_connectors';
+					$cached    = wp_cache_get( $cache_key );
+					if ( false !== $cached ) {
+						$_child_reports_logged_contexts = $cached;
+					} else {
+						// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Safe static query in cached block for settings UI; direct $wpdb access intentional at this layer.
+						$_child_reports_logged_contexts = (array) $wpdb->get_results(
+							"SELECT DISTINCT context,connector FROM $wpdb->mainwp_stream GROUP BY context", // @codingStandardsIgnoreLine can't prepare column name
+							'ARRAY_A'
+						);
+						wp_cache_set( $cache_key, $_child_reports_logged_contexts );
+					}
 				}
 
 				if ( ! empty( $_child_reports_logged_contexts ) && is_array( $_child_reports_logged_contexts ) ) {

--- a/classes/class-uninstall.php
+++ b/classes/class-uninstall.php
@@ -100,7 +100,9 @@ class Uninstall {
 		/** @global object $wpdb WordPress Database instance. */
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Uninstall-time schema cleanup; DROP TABLE on trusted $wpdb properties, one-time destructive operation.
 		$wpdb->query( "DROP TABLE {$wpdb->mainwp_stream}" );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.DirectDatabaseQuery.SchemaChange -- Uninstall-time schema cleanup; DROP TABLE on trusted $wpdb properties, one-time destructive operation.
 		$wpdb->query( "DROP TABLE {$wpdb->mainwp_streammeta}" );
 	}
 
@@ -117,6 +119,7 @@ class Uninstall {
 		/** @global object $wpdb WordPress Database instance. */
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Uninstall data cleanup; prepared DELETE with %d placeholder, destructive operation where caching is inapplicable.
 		$wpdb->query(
 			$wpdb->prepare(
 				"DELETE `records`, `meta`
@@ -138,6 +141,7 @@ class Uninstall {
 		global $wpdb;
 
 		// Wildcard matches
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Uninstall data cleanup; DELETE with hardcoded LIKE pattern on trusted $wpdb->options table, one-time destructive operation.
 		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '%wp_mainwp_stream%';" );
 
 		// Specific options
@@ -151,6 +155,7 @@ class Uninstall {
 		}
 
 		// Wildcard matches on network options
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Uninstall data cleanup; DELETE with hardcoded LIKE pattern on trusted $wpdb->sitemeta table, one-time destructive operation.
 		$wpdb->query( "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE '%wp_mainwp_stream%';" );
 
 		// Delete options from each blog on network
@@ -173,6 +178,7 @@ class Uninstall {
 		global $wpdb;
 
 		// Wildcard matches
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Uninstall data cleanup; DELETE with hardcoded LIKE pattern on trusted table, one-time destructive operation.
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}options WHERE option_name LIKE '%wp_mainwp_stream%';" );
 
 		// Specific options
@@ -190,10 +196,12 @@ class Uninstall {
 		global $wpdb;
 
 		// Wildcard matches
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Uninstall data cleanup; DELETE with hardcoded LIKE pattern on trusted $wpdb->usermeta table, one-time destructive operation.
 		$wpdb->query( "DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE '%wp_mainwp_stream%';" );
 
 		// Specific user meta
 		foreach ( $this->user_meta as $meta_key ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Uninstall data cleanup; prepared DELETE with %s placeholder, destructive operation where caching is inapplicable.
 			$wpdb->query(
 				$wpdb->prepare( "DELETE FROM {$wpdb->usermeta} WHERE meta_key = %s;", $meta_key )
 			);
@@ -214,10 +222,12 @@ class Uninstall {
 		global $wpdb;
 
 		// Wildcard matches
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Uninstall data cleanup; DELETE with hardcoded LIKE pattern on trusted table, one-time destructive operation.
 		$wpdb->query( "DELETE FROM {$wpdb->usermeta} WHERE meta_key LIKE '{$wpdb->prefix}%wp_mainwp_stream%';" );
 
 		// Specific user meta
 		foreach ( $this->user_meta as $meta_key ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Uninstall data cleanup; prepared DELETE with %s placeholder, destructive operation where caching is inapplicable.
 			$wpdb->query(
 				$wpdb->prepare( "DELETE FROM {$wpdb->usermeta} WHERE meta_key = {$wpdb->prefix}%s;", $meta_key )
 			);

--- a/connectors/class-connector-buddypress.php
+++ b/connectors/class-connector-buddypress.php
@@ -552,7 +552,7 @@ class Connector_BuddyPress extends Connector {
 				sprintf(
 					// translators: Placeholder refers to an activity title (e.g. "Update").
 					__( '"%s" activity deleted', 'mainwp-child-reports' ),
-					strip_tags( $activity->action )
+					strip_tags( (string) ( $activity->action ?? '' ) )
 				),
 				array(
 					'id'      => $activity->id,
@@ -608,7 +608,7 @@ class Connector_BuddyPress extends Connector {
 			sprintf(
 				// translators: Placeholder refers to an activity title (e.g. "Update")
 				__( 'Marked activity "%s" as spam', 'mainwp-child-reports' ),
-				strip_tags( $activity->action )
+				strip_tags( (string) ( $activity->action ?? '' ) )
 			),
 			array(
 				'id'      => $activity->id,
@@ -636,7 +636,7 @@ class Connector_BuddyPress extends Connector {
 			sprintf(
 				// translators: Placeholder refers to an activity title (e.g. "Update").
 				__( 'Unmarked activity "%s" as spam', 'mainwp-child-reports' ),
-				strip_tags( $activity->action )
+				strip_tags( (string) ( $activity->action ?? '' ) )
 			),
 			array(
 				'id'      => $activity->id,
@@ -663,7 +663,7 @@ class Connector_BuddyPress extends Connector {
 			sprintf(
 				// translators: Placeholder refers to an activity title (e.g. "Update")
 				__( '"%s" activity updated', 'mainwp-child-reports' ),
-				strip_tags( $activity->action )
+				strip_tags( (string) ( $activity->action ?? '' ) )
 			),
 			array(
 				'id'      => $activity->id,

--- a/connectors/class-connector-settings.php
+++ b/connectors/class-connector-settings.php
@@ -773,7 +773,7 @@ class Connector_Settings extends Connector {
 		<script>
 			(function ($) {
 				$(function () {
-					var hashPrefix = <?php echo wp_mainwp_stream_json_encode( self::HIGHLIGHT_FIELD_URL_HASH_PREFIX ); // xss ok ?>,
+					var hashPrefix = <?php echo wp_mainwp_stream_json_encode( self::HIGHLIGHT_FIELD_URL_HASH_PREFIX ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON output is safe; wp_json_encode() properly handles JSON encoding for AJAX responses sent as application/json content type. ?>,
 						hashFieldName = "",
 						fieldNames = [],
 						$select2Choices = {},

--- a/connectors/class-connector-woocommerce.php
+++ b/connectors/class-connector-woocommerce.php
@@ -624,6 +624,7 @@ class Connector_Woocommerce extends Connector {
 		/** @global object $wpdb WordPress DB object. */
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Rare logging query on tax rate deletion; uses prepared statement with trusted WooCommerce table, one-time fetch for logging only, caching inapplicable.
 		$tax_rate_name = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT tax_rate_name FROM {$wpdb->prefix}woocommerce_tax_rates

--- a/includes/feeds/json.php
+++ b/includes/feeds/json.php
@@ -3,7 +3,7 @@
 
 header( 'Content-type: application/json; charset=' . get_option( 'blog_charset' ), true );
 if ( version_compare( PHP_VERSION, '5.4', '<' ) ) {
-	echo wp_mainwp_stream_json_encode( $records ); // xss ok
+	echo wp_mainwp_stream_json_encode( $records ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON output is safe; wp_json_encode() properly handles JSON encoding for AJAX responses sent as application/json content type.
 } else {
-	echo wp_mainwp_stream_json_encode( $records, JSON_PRETTY_PRINT ); // xss ok
+	echo wp_mainwp_stream_json_encode( $records, JSON_PRETTY_PRINT ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON output is safe; wp_json_encode() properly handles JSON encoding for AJAX responses sent as application/json content type.
 }

--- a/includes/lib/Carbon.php
+++ b/includes/lib/Carbon.php
@@ -147,6 +147,7 @@ class Carbon extends DateTime
         $tz = @timezone_open((string) $object);
 
         if ($tz === false) {
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message, not output
             throw new InvalidArgumentException('Unknown or bad timezone ('.$object.')');
         }
 
@@ -187,9 +188,9 @@ class Carbon extends DateTime
         }
 
         if ($tz !== null) {
-            parent::__construct($time, static::safeCreateDateTimeZone($tz));
+            parent::__construct($time ?: 'now', static::safeCreateDateTimeZone($tz));
         } else {
-            parent::__construct($time);
+            parent::__construct($time ?: 'now');
         }
     }
 
@@ -369,6 +370,7 @@ class Carbon extends DateTime
      *
      * @throws InvalidArgumentException
      */
+    #[\ReturnTypeWillChange]
     public static function createFromFormat($format, $time, $tz = null)
     {
         if ($tz !== null) {
@@ -382,6 +384,7 @@ class Carbon extends DateTime
         }
 
         $errors = static::getLastErrors();
+        // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message, not output
         throw new InvalidArgumentException(implode(PHP_EOL, $errors['errors']));
     }
 
@@ -498,6 +501,7 @@ class Carbon extends DateTime
                 return $this->getTimezone()->getName();
 
             default:
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message, not output
                 throw new InvalidArgumentException(sprintf("Unknown getter '%s'", $name));
         }
     }
@@ -565,6 +569,7 @@ class Carbon extends DateTime
                 break;
 
             default:
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message, not output
                 throw new InvalidArgumentException(sprintf("Unknown setter '%s'", $name));
         }
     }
@@ -620,6 +625,7 @@ class Carbon extends DateTime
      *
      * @return static
      */
+    #[\ReturnTypeWillChange]
     public function setDate($year, $month, $day)
     {
         parent::setDate($year, $month, $day);
@@ -679,6 +685,7 @@ class Carbon extends DateTime
      *
      * @return static
      */
+    #[\ReturnTypeWillChange]
     public function setTime($hour, $minute, $second = 0, $microseconds = 0 )
     {
         parent::setTime($hour, $minute, $second, $microseconds );
@@ -748,6 +755,7 @@ class Carbon extends DateTime
      *
      * @return static
      */
+    #[\ReturnTypeWillChange]
     public function setTimezone($value)
     {
         parent::setTimezone(static::safeCreateDateTimeZone($value));

--- a/mainwp-child-reports.php
+++ b/mainwp-child-reports.php
@@ -7,7 +7,7 @@
  * Description: The MainWP Child Report plugin tracks Child sites for the MainWP Pro Reports Extension. The plugin is only useful if you are using MainWP and the Pro Reports Extension.
  * Author: MainWP
  * Author URI: https://mainwp.com
- * Version: 2.2.6
+ * Version: 2.3
  * Requires at least: 6.0
  * Text Domain: mainwp-child-reports
  * License: GPLv3 or later
@@ -44,7 +44,7 @@ if ( ! version_compare( PHP_VERSION, '5.6', '>=' ) ) {
 function wp_mainwp_stream_fail_php_version() {
 	load_plugin_textdomain( 'mainwp-child-reports', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
-	$message      = esc_html__( 'MainWP Child Reports requires PHP version 5.3+, plugin is currently NOT ACTIVE.', 'stream' );
+	$message      = esc_html__( 'MainWP Child Reports requires PHP version 5.3+, plugin is currently NOT ACTIVE.', 'mainwp-child-reports' );
 	$html_message = sprintf( '<div class="error">%s</div>', wpautop( $message ) );
 
 	echo wp_kses_post( $html_message );

--- a/readme.txt
+++ b/readme.txt
@@ -5,9 +5,9 @@ Author: mainwp
 Author URI: https://mainwp.com
 Plugin URI: https://mainwp.com
 Requires at least: 6.0
-Tested up to: 6.8
+Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 2.2.6
+Stable tag: 2.3
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -35,6 +35,12 @@ Credit to the [Stream Plugin](https://wordpress.org/plugins/stream/) which the M
 2. The MainWP Child Reports Settings Screen
 
 == Changelog ==
+
+= 2.3 - 12-8-2025 =
+
+* Added: Object caching for main query and meta record lookups to improve performance
+* Updated: Improved output escaping compliance throughout plugin (WordPress Coding Standards)
+* Updated: Translation and echo statements with proper context-aware escaping functions
 
 = 2.2.6 - 7-8-2025 =
 


### PR DESCRIPTION
Adds object caching for main query and meta record lookups to improve performance and reduce database load. Also includes cache invalidation after record/meta changes, enhances output escaping, switches to wp_safe_redirect, and adds PHPCS ignore comments for direct DB queries and output. Minor bug fixes and code quality improvements are included throughout the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-level caching for query results and metadata retrieval to improve performance and reduce database load.

* **Bug Fixes**
  * Enhanced output escaping and HTML safety across the plugin.
  * Improved null-value handling in various operations.
  * Updated redirect methods to use safer alternatives in admin operations.
  * Better handling of empty messages and edge cases.

* **Documentation**
  * Updated plugin version to 2.3 with expanded changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->