### PR TITLE
Fix: Theme ZIP install debug warnings in MainWP Child Reports / Child

### DIFF
--- a/classes/class-db-driver-wpdb.php
+++ b/classes/class-db-driver-wpdb.php
@@ -91,9 +91,11 @@ class DB_Driver_WPDB implements DB_Driver {
 		// Insert record meta
 		foreach ( (array) $meta as $key => $vals ) {
 			foreach ( (array) $vals as $val ) {
+				$val = $this->normalize_meta_value( $val );
 				if ( null === $val ) {
 					continue;
 				}
+
 				$this->insert_meta( $record_id, $key, $val );
 			}
 		}
@@ -130,6 +132,37 @@ class DB_Driver_WPDB implements DB_Driver {
 
 		return $result;
 	}
+
+	/**
+	 * Normalize meta values before inserting them into the DB.
+	 *
+	 * @param mixed $value Meta value.
+	 *
+	 * @return scalar|string|null
+	 */
+	private function normalize_meta_value( $value ) {
+        if ( null === $value || is_resource( $value ) ) {
+            return null;
+        }
+
+        if ( is_bool( $value ) ) {
+            return $value ? '1' : '0';
+        }
+
+        if ( is_scalar( $value ) ) {
+            if ( is_string( $value ) && is_email( $value ) ) {
+                return sanitize_email( $value );
+            }
+
+            return $value;
+        }
+
+        if ( is_array( $value ) || is_object( $value ) ) {
+            return maybe_serialize( $value );
+        }
+
+        return null;
+    }
 
 	/**
 	 * Retrieve records

--- a/classes/class-db-driver-wpdb.php
+++ b/classes/class-db-driver-wpdb.php
@@ -91,6 +91,9 @@ class DB_Driver_WPDB implements DB_Driver {
 		// Insert record meta
 		foreach ( (array) $meta as $key => $vals ) {
 			foreach ( (array) $vals as $val ) {
+				if ( null === $val ) {
+					continue;
+				}
 				$this->insert_meta( $record_id, $key, $val );
 			}
 		}

--- a/connectors/class-connector-installer.php
+++ b/connectors/class-connector-installer.php
@@ -731,7 +731,8 @@ class Connector_Installer extends Connector {
 				$name    = $args['Name'];
 				$version = $args['Version'];
 			} else { // theme
-				$slug = $this->normalize_theme_slug( $args['slug'] );
+                $raw_slug = ! empty( $args['slug'] ) ? $args['slug'] : null;
+				$slug = $this->normalize_theme_slug( $raw_slug );
 				if ( ! $slug ) {
 					return;
 				}

--- a/connectors/class-connector-installer.php
+++ b/connectors/class-connector-installer.php
@@ -89,6 +89,29 @@ class Connector_Installer extends Connector {
 	}
 
 	/**
+	 * Normalize a theme reference into a stylesheet slug.
+	 *
+	 * @param mixed $theme Theme slug or WP_Theme instance.
+	 *
+	 * @return string|null
+	 */
+	private function normalize_theme_slug( $theme ) {
+		if ( $theme instanceof \WP_Theme ) {
+			$theme = $theme->get_stylesheet();
+		}
+
+		if ( is_scalar( $theme ) ) {
+			$theme = (string) $theme;
+		}
+
+		if ( ! is_string( $theme ) || '' === $theme ) {
+			return null;
+		}
+
+		return $theme;
+	}
+
+	/**
 	 * Add action links to Stream drop row in admin list screen.
 	 *
 	 * @filter wp_mainwp_stream_action_links_{connector}.
@@ -224,7 +247,7 @@ class Connector_Installer extends Connector {
 				$name    = $data['Name'];
 				$version = $data['Version'];
 			} else { // theme
-				$slug = $upgrader->theme_info();
+				$slug = $this->normalize_theme_slug( $upgrader->theme_info() );
 
 				if ( ! $slug ) {
 					return false;
@@ -708,7 +731,7 @@ class Connector_Installer extends Connector {
 				$name    = $args['Name'];
 				$version = $args['Version'];
 			} else { // theme
-				$slug = $args['slug'];
+				$slug = $this->normalize_theme_slug( $args['slug'] );
 				if ( ! $slug ) {
 					return;
 				}

--- a/connectors/class-connector-installer.php
+++ b/connectors/class-connector-installer.php
@@ -339,10 +339,15 @@ class Connector_Installer extends Connector {
 			$old_version = isset( $log['old_version'] ) ? $log['old_version'] : null;
 			$message     = isset( $log['message'] ) ? $log['message'] : null;
 			$action      = isset( $log['action'] ) ? $log['action'] : null;
+			$log_args    = compact( 'type', 'name', 'version', 'slug', 'success', 'error', 'old_version' );
+
+			if ( null === $slug || '' === $slug ) {
+				unset( $log_args['slug'] );
+			}
 
 			$this->log(
 				$message,
-				compact( 'type', 'name', 'version', 'slug', 'success', 'error', 'old_version' ),
+				$log_args,
 				null,
 				$context,
 				$action


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented null metadata from being written during record insertion, improving data integrity and avoiding invalid entries.
  * Improved automatic-update logging to avoid recording empty or missing identifiers and to ensure log entries only include valid fields.
  * Accept theme references in multiple formats when resolving theme identifiers, preventing empty or invalid slugs from being recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->